### PR TITLE
Add CSS auto width to .colorpicker input field

### DIFF
--- a/paintstore/static/paintstore/css/colorpicker.css
+++ b/paintstore/static/paintstore/css/colorpicker.css
@@ -6,7 +6,7 @@
 	background: url(../images/colorpicker_background.png);
 	font-family: Arial, Helvetica, sans-serif;
 	display: none;
-    z-index: 999;
+	z-index: 999;
 }
 .colorpicker_color {
 	width: 150px;
@@ -82,6 +82,7 @@
 	margin: 0;
 	padding: 0;
 	height: 11px;
+	width: auto;
 }
 .colorpicker_hex {
 	position: absolute;
@@ -161,16 +162,16 @@
 	background-position: bottom;
 }
 .colorSelector {
-    position: relative;
-    width: 36px;
-    height: 36px;
-    left: 35%;
-    margin-top: 5px;
-    margin-bottom: 5px;
-    background: url(../images/select.png);
+	position: relative;
+	width: 36px;
+	height: 36px;
+	left: 35%;
+	margin-top: 5px;
+	margin-bottom: 5px;
+	background: url(../images/select.png);
 }
 .colorSelector div {
-    position: absolute;
+	position: absolute;
 	top: 3px;
 	left: 3px;
 	width: 30px;


### PR DESCRIPTION
One of the applications I'm working with for one reason or another has set the width attribute of 'input' to be a certain amount of pixels. This breaks the colorpicker widget as it ends up with large fields. This PR simply specifies the inputs to have an automatic width so that other CSS can't break it.

As a bonus, I also fixed some inconsistent indentation in the CSS (spaces vs tabs).
